### PR TITLE
Introduce Package Manager

### DIFF
--- a/Calabash Launcher Core/.gitignore
+++ b/Calabash Launcher Core/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/Calabash Launcher Core/Package.swift
+++ b/Calabash Launcher Core/Package.swift
@@ -7,22 +7,16 @@ let package = Package(
     name: "Calabash Launcher Core",
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "Calabash Launcher Core",
-            targets: ["Calabash Launcher Core"]),
+        .library(name: "Calabash Launcher Core", targets: ["Calabash Launcher Core"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/q231950/commands.git", from: "0.0.3"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(
-            name: "Calabash Launcher Core",
-            dependencies: []),
-        .testTarget(
-            name: "Calabash Launcher CoreTests",
-            dependencies: ["Calabash Launcher Core"]),
+        .target(name: "Calabash Launcher Core", dependencies: ["Commands"]),
+        .testTarget(name: "Calabash Launcher CoreTests", dependencies: ["Calabash Launcher Core"]),
     ]
 )

--- a/Calabash Launcher Core/Package.swift
+++ b/Calabash Launcher Core/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Calabash Launcher Core",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Calabash Launcher Core",
+            targets: ["Calabash Launcher Core"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "Calabash Launcher Core",
+            dependencies: []),
+        .testTarget(
+            name: "Calabash Launcher CoreTests",
+            dependencies: ["Calabash Launcher Core"]),
+    ]
+)

--- a/Calabash Launcher Core/README.md
+++ b/Calabash Launcher Core/README.md
@@ -1,0 +1,3 @@
+# Calabash Launcher Core
+
+A description of this package.

--- a/Calabash Launcher Core/Sources/Calabash Launcher Core/Calabash_Launcher_Core.swift
+++ b/Calabash Launcher Core/Sources/Calabash Launcher Core/Calabash_Launcher_Core.swift
@@ -1,0 +1,3 @@
+struct Calabash_Launcher_Core {
+    var text = "Hello, World!"
+}

--- a/Calabash Launcher Core/Tests/Calabash Launcher CoreTests/Calabash_Launcher_CoreTests.swift
+++ b/Calabash Launcher Core/Tests/Calabash Launcher CoreTests/Calabash_Launcher_CoreTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Calabash_Launcher_Core
+
+class Calabash_Launcher_CoreTests: XCTestCase {
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(Calabash_Launcher_Core().text, "Hello, World!")
+    }
+
+
+    static var allTests = [
+        ("testExample", testExample),
+    ]
+}

--- a/Calabash Launcher Core/Tests/LinuxMain.swift
+++ b/Calabash Launcher Core/Tests/LinuxMain.swift
@@ -1,0 +1,6 @@
+import XCTest
+@testable import Calabash_Launcher_CoreTests
+
+XCTMain([
+    testCase(Calabash_Launcher_CoreTests.allTests),
+])

--- a/Calabash Launcher.xcodeproj/project.pbxproj
+++ b/Calabash Launcher.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3B9639FC1F93C4DA006E86C5 /* Calabash_Launcher_Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B9639FD1F93C4DA006E86C5 /* Calabash_Launcher_Core.framework */; };
 		5D948C901F8F4BDA0001BC50 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D948C8F1F8F4BDA0001BC50 /* Extensions.swift */; };
 		5D948C921F8F4FC40001BC50 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D948C911F8F4FC40001BC50 /* Constants.swift */; };
 		5D948C941F8F556D0001BC50 /* Language.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D948C931F8F556D0001BC50 /* Language.swift */; };
@@ -60,6 +61,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		3B9639FD1F93C4DA006E86C5 /* Calabash_Launcher_Core.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Calabash_Launcher_Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5D948C8F1F8F4BDA0001BC50 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		5D948C911F8F4FC40001BC50 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		5D948C931F8F556D0001BC50 /* Language.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Language.swift; sourceTree = "<group>"; };
@@ -107,18 +109,28 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3B9639FC1F93C4DA006E86C5 /* Calabash_Launcher_Core.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3B9639FB1F93C4DA006E86C5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3B9639FD1F93C4DA006E86C5 /* Calabash_Launcher_Core.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		ED4C14D41DB29FB700A1190E = {
 			isa = PBXGroup;
 			children = (
 				EDD303971F8F88400042E27F /* Launcher */,
 				EDD303931F8F869B0042E27F /* Scripts */,
 				ED4C14DE1DB29FB700A1190E /* Products */,
+				3B9639FB1F93C4DA006E86C5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};

--- a/Calabash Launcher.xcworkspace/contents.xcworkspacedata
+++ b/Calabash Launcher.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "container:Calabash Launcher.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Calabash Launcher Core/Calabash Launcher Core.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Launcher/Classes/Controllers/TagsController.swift
+++ b/Launcher/Classes/Controllers/TagsController.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CommandsCore
 
 class TagsController {
     


### PR DESCRIPTION
Introduces a framework, the `Calabash Launcher Core` and adds support for the Swift Package Manager. 

It also [adds a dependency](https://github.com/JoeSSS/calabash-launcher/compare/package_manager?expand=1#diff-6267f05beda9ca9bd60b53d5880bd24cR14) to a Swift Package that allows executing scripts and reading the output.

**Calabash Launcher Core:**
- is on its own a Swift Package
- depends on [Commands](https://github.com/q231950/commands)