### PR TITLE
Initialize the optional variable correctly

### DIFF
--- a/Launcher/Classes/ViewControllers/InspectorViewController.swift
+++ b/Launcher/Classes/ViewControllers/InspectorViewController.swift
@@ -51,7 +51,6 @@ class InspectorViewController: NSViewController, NSTableViewDataSource {
     }
     
     override func viewDidAppear() {
-        textViewPrinter = TextViewPrinter(textView: outputText)
         outputText.backgroundColor = .darkAquamarine
         outputText.textColor = .lightGreen
         localizedTextField.textColor = .black
@@ -71,6 +70,7 @@ class InspectorViewController: NSViewController, NSTableViewDataSource {
         self.startDeviceButton.isEnabled = true
         self.gestureRecognizer.isEnabled = true
         self.cloneButton.isHidden = true
+        textViewPrinter = TextViewPrinter(textView: outputText)
     }
 
     @IBAction func doubleClickedItem(_ sender: NSOutlineView) {


### PR DESCRIPTION
@danielknott just found a crash when Simulator sent some output back to the text view. Unfortunately the optional value `textViewPrinter` was not initialized before.