### PR TITLE
Filtering accidental output

### DIFF
--- a/Launcher/Classes/ViewControllers/TasksViewController.swift
+++ b/Launcher/Classes/ViewControllers/TasksViewController.swift
@@ -282,7 +282,7 @@ class TasksViewController: NSViewController {
         if let launchPath = Constants.FilePaths.Bash.simulators {
             let outputStream = CommandTextOutputStream()
             outputStream.textHandler = { text in
-                let filderedText = text.components(separatedBy: "\n").filter { !$0.isEmpty }
+                let filderedText = text.components(separatedBy: "\n").filter { $0.contains("Simulator") }
                 DispatchQueue.main.async {
                     self.phoneComboBox.addItems(withTitles: filderedText)
                 }


### PR DESCRIPTION
Fixes #92

Filtering accidental output by checking that line contains "Simulator" word. This is not ideal, but blacklisting can be even worse.